### PR TITLE
Mike/stack bug

### DIFF
--- a/DavidAsmCore/OpEmitter.cs
+++ b/DavidAsmCore/OpEmitter.cs
@@ -35,6 +35,10 @@ namespace DavidAsmCore
             _writer.WritePaddingByte();
         }
 
+        public void WriteComment(string comment)
+        {
+            _writer.WriteComment(comment);
+        }
 
         public void MarkLabel(Label label)        
         {

--- a/DavidAsmCore/Register.cs
+++ b/DavidAsmCore/Register.cs
@@ -50,8 +50,8 @@ namespace DavidAsmCore
             }
 
             // 6 is IP. 
-
-            int maxReg = 5;
+            // R5 is reserver for stack ... don't allow referencing it. 
+            int maxReg = 4;
             if (regId < 0 || regId > maxReg)
             {
                 throw new InvalidOperationException($"Invalid register index. Only supports r1...r{maxReg}");

--- a/DavidAsmCore/Worker.cs
+++ b/DavidAsmCore/Worker.cs
@@ -371,7 +371,7 @@ namespace DavidAsmCore
 
             _emitter.WriteComment($"Push {r}");
             _emitter.MoveRegToMem(r, _stackAddr);
-            _emitter.Add(Register.R5, 1, Register.R5);
+            _emitter.Add(Register.R5, 2, Register.R5); // each stack item is two bytes
         }
 
         // Pop a value and save to the register. 
@@ -383,8 +383,8 @@ namespace DavidAsmCore
             }
 
             _emitter.WriteComment($"Pop {r}");
-            _emitter.Add(Register.R5, -1, Register.R5);
-            _emitter.MoveMemToReg(_stackAddr, r);            
+            _emitter.Add(Register.R5, -2, Register.R5); // each stack item is two bytes
+            _emitter.MoveMemToReg(_stackAddr, r);
         }
     }
 }

--- a/DavidAsmCore/Worker.cs
+++ b/DavidAsmCore/Worker.cs
@@ -128,10 +128,11 @@ namespace DavidAsmCore
                 // Emit return opcodes. 
                 //_emitter.Add(Register.R5, 8, Register.R5);
 
+                // Use R4 as a temp register. 
                 _emitter.WriteComment($"{_currentFunc._name} return.");
-                EmitPop(Register.R5);
-                _emitter.Add(Register.R5, 12, Register.R5);
-                _emitter.JumpReg(Register.R5);
+                EmitPop(Register.R4);
+                _emitter.Add(Register.R4, 12, Register.R4);
+                _emitter.JumpReg(Register.R4);
 
                 _currentFunc = null;
                 return;
@@ -363,6 +364,11 @@ namespace DavidAsmCore
         // Emit pushing a register onto the stack
         private void EmitPush(Register r)
         {
+            if (r.Value == Register.R5.Value)
+            {
+                throw new InvalidOperationException($"Can't push R5 since it's the stack register.");
+            }
+
             _emitter.WriteComment($"Push {r}");
             _emitter.MoveRegToMem(r, _stackAddr);
             _emitter.Add(Register.R5, 1, Register.R5);
@@ -371,6 +377,11 @@ namespace DavidAsmCore
         // Pop a value and save to the register. 
         private void EmitPop(Register r)
         {
+            if (r.Value == Register.R5.Value)
+            {
+                throw new InvalidOperationException($"Can't pop to R5 since it's the stack register.");
+            }
+
             _emitter.WriteComment($"Pop {r}");
             _emitter.Add(Register.R5, -1, Register.R5);
             _emitter.MoveMemToReg(_stackAddr, r);            

--- a/DavidAsmCore/Writer.cs
+++ b/DavidAsmCore/Writer.cs
@@ -17,6 +17,12 @@ namespace DavidAsmCore
         // Mapping of annotations ahead of each byte offset. 
         private Dictionary<int, StringBuilder> _annotations = new Dictionary<int, StringBuilder>();
 
+        // Map of label to where it's used. 
+        private readonly Dictionary<Label, List<int>> _touchUps = new Dictionary<Label, List<int>>();
+
+        // Track map of labels to their offets. 
+        private readonly Dictionary<Label, int> _labelOffsets = new Dictionary<Label, int>();
+
         public Writer()
         {
         }
@@ -25,7 +31,6 @@ namespace DavidAsmCore
         public void WriteToFile(TextWriter output, bool compact=false)
         {
             ApplyTouchups();
-
 
             // foreach(var b in _bytes)
             for(var i = 0; i < _bytes.Count; i++)
@@ -138,12 +143,6 @@ namespace DavidAsmCore
             // Placeholder to fill in later. 
             this.WriteI16(0);
         }
-
-        // Map of label to where it's used. 
-        private readonly Dictionary<Label, List<int>> _touchUps = new Dictionary<Label, List<int>>();
-        
-        // Track map of labels to their offets. 
-        private readonly Dictionary<Label, int> _labelOffsets = new Dictionary<Label, int>();
 
         public void ApplyTouchups()
         {

--- a/samples/recursion1.david
+++ b/samples/recursion1.david
@@ -1,0 +1,28 @@
+// Basic recusion test 
+
+val 3 --> r1
+
+val 10 --> r2
+
+call Recursion1
+
+exit
+
+Recursion1:
+{
+    // Param1 is in R1 
+
+    add r2 r1 --> r2
+
+    add r1 -1 --> r1
+    
+    // if r1 > 0, goto Done 
+    jmp.if KeepGoing r1 
+    
+    jmp Done 
+KeepGoing: 
+    call Recursion1     
+   
+Done:
+
+}


### PR DESCRIPTION
Code generation was using register 5 as a pop to register, when r5 was the stack pointer. To fix this, we assigned r4 as the pop to register. This means that r4 is the register that has the stack pointer value upon popping. This also means that r4 can't be used during a time when the stack is in use. 